### PR TITLE
Removing a UNICODE control character

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 layout: workshop      # DON'T CHANGE THIS.
 root: .               # DON'T CHANGE THIS EITHER.  (THANK YOU.)
 carpentry: "swc"    # what kind of Carpentry (must be either "dc" or "swc")
-venue: "LCG-Aula	1-2, Centro de Ciencias Genómicas, UNAM"        # brief name of host site without address (e.g., "Euphoric State University")
+venue: "LCG-Aula 1-2, Centro de Ciencias Genómicas, UNAM"        # brief name of host site without address (e.g., "Euphoric State University")
 address: " Centro de Ciencias Genómicas Av. Universidad s/n Col. Chamilpa 62210, Cuernavaca, Morelos"      # full street address of workshop (e.g., "Room A, 123 Forth Street, Blimingen, Euphoria")
 country: "mx"      # lowercase two-letter ISO country code such as "fr" (see https://en.wikipedia.org/wiki/ISO_3166-1)
 language: "es"     # lowercase two-letter ISO language code such as "fr" (see https://en.wikipedia.org/wiki/ISO_639-1)


### PR DESCRIPTION
Please merge this PR as this control character is causing our past workshops site [1] not to display properly.

[1] - https://software-carpentry.org/workshops/past/